### PR TITLE
fix: found function to save quote id in customer form

### DIFF
--- a/django_insurance/quote/views.py
+++ b/django_insurance/quote/views.py
@@ -22,10 +22,13 @@ class Customer_CreateView(CreateView):
         "zip_code",
         "email_address",
         "date_of_birth",
-        "home_ownership",
-        "quote_id"
+        "home_ownership"
     ]
     template_name = "customer.html"
+
+    def form_valid(self, form):
+        form.instance.quote_id = self.quote_id
+        return super().form_valid(form)
 
     def get_success_url(self):
         return "/driver"


### PR DESCRIPTION
not displayed as a form field in the UI - saves to the db as expected.
![image](https://github.com/user-attachments/assets/05584884-ec50-4062-ba83-652971a9672f)